### PR TITLE
Update __init__.py

### DIFF
--- a/stingray/__init__.py
+++ b/stingray/__init__.py
@@ -1,3 +1,3 @@
 from stingray.lightcurve import *
 from stingray.utils import *
-from powerspectrum import *
+from stingray.powerspectrum import *


### PR DESCRIPTION
fix absolute import deprecation on python 3: `from powerspectrum import *` to  `from stingray.powerspectrum import *`
