### PR TITLE
Update test_powerspectrum.py

### DIFF
--- a/tests/test_powerspectrum.py
+++ b/tests/test_powerspectrum.py
@@ -196,7 +196,7 @@ class TestPowerspectrum(object):
         had better be 'method'
         """
         ps = Powerspectrum(lc = self.lc, norm="Leahy")
-        assert ps.rebin.func_defaults[0] == "mean"
+        assert ps.rebin.__defaults__[0] == "mean"
 
     def rebin_several(self, df):
         """


### PR DESCRIPTION
uses `__defaults__` instead of `func_defaults` for python 2 and 3 compatibility
