### PR TITLE
Patch uncertainties2 -- err keyword and changes on utils.rebin_data

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -23,13 +23,13 @@ class Lightcurve(object):
 
         counts: iterable, optional, default None
             A list or array of the counts in each bin corresponding to the
-            bins defined in `time` (note: **not** the count rate, i.e.
-            counts/second, but the counts/bin).
+            bins defined in `time` (note: use input_counts=False to input the
+            count rate, i.e. counts/second, otherwise use counts/bin).
 
         err: iterable, optional, default None
             A list or array of the uncertainties (or standard deviation) in
             each bin corresponding to the bins defined in `time`. In units of
-            counts/bin or counts/second (see `input_counts` parameter).
+            counts/bin or counts/second (see `input_counts`).
             If None (default), it assumes the data is Poisson distributed.
 
         input_counts: bool, optional, default True

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -11,7 +11,7 @@ import numpy as np
 import stingray.utils as utils
 
 class Lightcurve(object):
-    def __init__(self, time, counts, input_counts=True):
+    def __init__(self, time, counts, err=None, input_counts=True):
         """
         Make a light curve object from an array of time stamps and an
         array of counts.
@@ -25,6 +25,12 @@ class Lightcurve(object):
             A list or array of the counts in each bin corresponding to the
             bins defined in `time` (note: **not** the count rate, i.e.
             counts/second, but the counts/bin).
+
+        err: iterable, optional, default None
+            A list or array of the uncertainties (or standard deviation) in
+            each bin corresponding to the bins defined in `time`. In units of
+            counts/bin or counts/second (see `input_counts` parameter).
+            If None (default), it assumes the data is Poisson distributed.
 
         input_counts: bool, optional, default True
             If True, the code assumes that the input data in 'counts'
@@ -74,13 +80,21 @@ class Lightcurve(object):
         if input_counts:
             self.counts = np.asarray(counts)
             self.countrate = self.counts/self.dt
-            self.counts_err = np.sqrt(self.counts)
-            self.countrate_err = np.sqrt(self.counts)/self.dt
+            if err == None:
+                self.counts_err = np.sqrt(self.counts)
+                self.countrate_err = np.sqrt(self.counts)/self.dt
+            else:
+                self.counts_err = self.err
+                self.counts_err = self.err/self.dt
         else:
             self.countrate = np.asarray(counts)
             self.counts = self.countrate*self.dt
-            self.counts_err = np.sqrt(self.counts)
-            self.countrate_err = np.sqrt(self.counts)/self.dt
+            if err == None:
+                self.counts_err = np.sqrt(self.counts)
+                self.countrate_err = np.sqrt(self.counts)/self.dt
+            else:
+                self.counts_err = self.err*self.dt
+                self.counts_err = self.err
 
         self.ncounts = self.counts.shape[0]
         self.tseg = self.time[-1] - self.time[0] + self.dt

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -74,27 +74,33 @@ class Lightcurve(object):
         assert np.all(np.isfinite(counts)), "There are inf or NaN values in " \
                                             "your counts array!"
 
+        try:
+                assert np.all(np.isfinite(err)), "There are inf or NaN values in " \
+                                                 "your err array!"
+        except TypeError:
+            pass
+
         self.time = np.asarray(time)
         self.dt = time[1] - time[0]
 
         if input_counts:
             self.counts = np.asarray(counts)
             self.countrate = self.counts/self.dt
-            if err == None:
+            if err is not None:
+                self.counts_err = err
+                self.countrate_err = err/self.dt
+            else:
                 self.counts_err = np.sqrt(self.counts)
                 self.countrate_err = np.sqrt(self.counts)/self.dt
-            else:
-                self.counts_err = self.err
-                self.counts_err = self.err/self.dt
         else:
             self.countrate = np.asarray(counts)
             self.counts = self.countrate*self.dt
-            if err == None:
+            if err is not None:
+                self.counts_err = err*self.dt
+                self.countrate_err = err
+            else:
                 self.counts_err = np.sqrt(self.counts)
                 self.countrate_err = np.sqrt(self.counts)/self.dt
-            else:
-                self.counts_err = self.err*self.dt
-                self.counts_err = self.err
 
         self.ncounts = self.counts.shape[0]
         self.tseg = self.time[-1] - self.time[0] + self.dt
@@ -192,9 +198,10 @@ class Lightcurve(object):
         assert dt_new >= self.dt, "New time resolution must be larger than " \
                                   "old time resolution!"
 
-        bin_time, bin_counts, _ = utils.rebin_data(self.time,
-                                                   self.counts,
-                                                   dt_new, method)
+        bin_time, bin_counts, bin_err, _ = utils.rebin_data(self.time,
+                                                           self.counts,
+                                                           self.counts_err,
+                                                           dt_new, method)
 
-        lc_new = Lightcurve(bin_time, bin_counts)
+        lc_new = Lightcurve(bin_time, bin_counts, err=bin_err)
         return lc_new

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -281,9 +281,11 @@ class Powerspectrum(object):
         """
 
         ## rebin power spectrum to new resolution
-        binfreq, binps, step_size = utils.rebin_data(self.freq[1:],
-                                                     self.ps[1:], df,
-                                                     method=method)
+        ## an empty variable is required to hold the yerr value returned
+        binfreq, binps, _, step_size = utils.rebin_data(self.freq[1:],
+                                                        self.ps[1:],
+                                                        self.ps_err[1:], df,
+                                                        method=method)
 
         ## make an empty periodogram object
         bin_ps = Powerspectrum()
@@ -323,6 +325,9 @@ class Powerspectrum(object):
         binps: numpy.ndarray
             the binned powers
 
+        binps_err: numpy.ndarray
+            the uncertainty of the binned powers
+
         nsamples: numpy.ndarray
             the samples of the original periodogramincluded in each
             frequency bin
@@ -350,6 +355,10 @@ class Powerspectrum(object):
         nsamples = np.array([len(binno[np.where(binno == i)[0]]) \
                              for i in xrange(np.max(binno))])
 
+        ## compute the uncertainty for each binned power
+        number_of_combined_powers = self.m*nsamples
+        binps_err = binps/np.sqrt(number_of_combined_powers)
+
         ## the frequency resolution
         df = np.diff(binfreq)
 
@@ -357,7 +366,7 @@ class Powerspectrum(object):
         ## last right bin edge
         binfreq = binfreq[:-1]+df/2.
 
-        return binfreq, binps, nsamples
+        return binfreq, binps, binps_err, nsamples
 
     def compute_rms(self, min_freq, max_freq):
         """

--- a/stingray/utils.py
+++ b/stingray/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def rebin_data(x, y, dx_new, method='sum'):
+def rebin_data(x, y, yerr, dx_new, method='sum'):
 
     """
     Rebin some data to an arbitrary new data resolution. Either sum
@@ -13,6 +13,9 @@ def rebin_data(x, y, dx_new, method='sum'):
 
     y: interable
         The independent variable to be binned
+
+    yerr: iterable
+        The array of standard deviations of y
 
     dx_new: float
         The new resolution of the dependent variable x
@@ -29,6 +32,9 @@ def rebin_data(x, y, dx_new, method='sum'):
 
     ybin: numpy.ndarray
         The binned quantity y
+
+    yerrbin: numpy.ndarray
+        The binned uncertainties of y. sqrt(sum(yerr**2))
     """
 
     dx_old = x[1] - x[0]
@@ -39,29 +45,40 @@ def rebin_data(x, y, dx_new, method='sum'):
     step_size = np.float(dx_new)/np.float(dx_old)
 
     output = []
+    erroutput = []
     for i in np.arange(0, y.shape[0], step_size):
         total = 0
+        errtotal = 0
 
         prev_frac = int(i+1) - i
         prev_bin = int(i)
         total += prev_frac * y[prev_bin]
+        errtotal += prev_frac * (yerr[prev_bin]**2)
 
         if i + step_size < len(x):
             # Fractional part of next bin:
             next_frac = i+step_size - int(i+step_size)
             next_bin = int(i+step_size)
             total += next_frac * y[next_bin]
+            errtotal += next_frac * (yerr[next_bin]**2)
 
         total += sum(y[int(i+1):int(i+step_size)])
+        errtotal += sum(yerr[int(i+1):int(i+step_size)]**2)
+
         output.append(total)
+        erroutput.append(errtotal)
+
 
     output = np.asarray(output)
+    erroutput = np.sqrt(np.asarray(erroutput))
 
     if method in ['mean', 'avg', 'average', 'arithmetic mean']:
         ybin = output/np.float(step_size)
+        yerrbin = erroutput/np.float(step_size)
 
     elif method == "sum":
         ybin = output
+        yerrbin = erroutput
     else:
         raise Exception("Method for summing or averaging not recognized. "
                         "Please enter either 'sum' or 'mean'.")
@@ -70,8 +87,9 @@ def rebin_data(x, y, dx_new, method='sum'):
 
     if tseg/dx_new % 1.0 > 0.0:
         ybin = ybin[:-1]
+        yerrbin = yerrbin[:-1]
 
     xbin = np.arange(ybin.shape[0])*dx_new + x[0]-dx_old/2.+dx_new/2.
 
 
-    return xbin, ybin, step_size
+    return xbin, ybin, yerrbin, step_size

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,42 +12,48 @@ class TestRebinData(object):
         self.counts = 2.0
         self.x = np.arange(self.dx/2, self.dx/2+self.n*self.dx, self.dx)
         self.y = np.zeros_like(self.x)+self.counts
+        self.yerr = np.sqrt(self.y)
 
     def test_new_stepsize(self):
         dx_new = 2.0
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, yerrbin, step_size = utils.rebin_data(self.x, self.y,
+                                                          self.yerr, dx_new)
         assert step_size == dx_new/self.dx
 
     def test_arrays(self):
         dx_new = 2.0
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, yerrbin, step_size = utils.rebin_data(self.x, self.y,
+                                                          self.yerr, dx_new)
         assert isinstance(xbin, np.ndarray)
         assert isinstance(ybin, np.ndarray)
 
     def test_length_matches(self):
         dx_new = 2.0
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, yerrbin, step_size = utils.rebin_data(self.x, self.y,
+                                                          self.yerr, dx_new)
         assert xbin.shape[0] == ybin.shape[0]
 
 
     def test_binned_counts(self):
         dx_new = 2.0
 
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, yerrbin, step_size = utils.rebin_data(self.x, self.y,
+                                                          self.yerr, dx_new)
 
         ybin_test = np.zeros_like(xbin) + self.counts*dx_new/self.dx
         assert np.allclose(ybin, ybin_test)
 
     def test_uneven_bins(self):
         dx_new = 1.5
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, yerrbin, step_size = utils.rebin_data(self.x, self.y,
+                                                          self.yerr, dx_new)
         assert np.isclose(xbin[1]-xbin[0], dx_new)
 
     def test_uneven_binned_counts(self):
         dx_new = 1.5
-        xbin, ybin, step_size = utils.rebin_data(self.x, self.y, dx_new)
+        xbin, ybin, yerrbin, step_size = utils.rebin_data(self.x, self.y,
+                                                          self.yerr, dx_new)
         print(xbin)
         print(ybin)
         ybin_test = np.zeros_like(xbin) + self.counts*dx_new/self.dx
         assert np.allclose(ybin_test, ybin)
-


### PR DESCRIPTION
Changelog
- Add an `err` keyword to `Litghcurve` with the uncertainties, otherwise assumes Poisson errors.
- Redefines the function `utils.rebin_data()` to bin the errors without assuming any statistics.
- Powerspectra errors are the averaged power divided by the number of powers.
- Small changes to docstring regarding the `input_counts` parameter
